### PR TITLE
Fix typo in spoofing alert

### DIFF
--- a/index.template.ejs
+++ b/index.template.ejs
@@ -174,7 +174,7 @@
               <div class="col-sm-6 offset-sm-3">
                 <h4 class="mb-4 title">
                   <i class="bi bi-exclamation-triangle-fill"></i>
-                  <div>Your browser is spoofing it's version number</div>
+                  <div>Your browser is spoofing its version number</div>
                 </h4>
                 <div class="title">
                   <i class="bi bi-exclamation-triangle-fill" style="visibility: hidden;"></i>


### PR DESCRIPTION
As a fan of your Chromium checker, I just noticed the spoofing alert, and "it's" should be "its". Thanks for your work!